### PR TITLE
Handle permission errors

### DIFF
--- a/config_keeper/commands/__init__.py
+++ b/config_keeper/commands/__init__.py
@@ -57,7 +57,12 @@ def push(
     """
 
     conf = config.load()
-    validator = ProjectValidator(conf, path_existence='error')
+    validator = ProjectValidator(
+        conf,
+        path_existence='error',
+        not_copyable_path='error',
+        not_writeable_path='skip',
+    )
 
     _validate_projects(projects, validator)
 
@@ -90,7 +95,12 @@ def pull(
     """
 
     conf = config.load()
-    validator = ProjectValidator(conf, path_existence='skip')
+    validator = ProjectValidator(
+        conf,
+        path_existence='skip',
+        not_copyable_path='skip',
+        not_writeable_path='error',
+    )
 
     _validate_projects(projects, validator)
 

--- a/config_keeper/commands/paths.py
+++ b/config_keeper/commands/paths.py
@@ -57,8 +57,7 @@ def add(
         if not match_:
             msg = (
                 f'{raw_path} is an invalid argument. Format must be as '
-                'follows:\n\n'
-                'key:/path/to/file/or/folder'
+                'follows: path_name:/path/to/file/or/folder'
             )
             raise exc.InvalidArgumentFormatError(msg)
         key = match_.group(1)

--- a/config_keeper/commands/project.py
+++ b/config_keeper/commands/project.py
@@ -108,7 +108,7 @@ def delete(
     if confirm:
         console.print('You are about delete the following project:\n')
         console.print(yaml.dump({project: conf['projects'][project]}))
-        if not typer.confirm('Confirm?'):
+        if not typer.confirm('Proceed?', default=True):
             raise typer.Exit
 
     del conf['projects'][project]

--- a/config_keeper/commands/project.py
+++ b/config_keeper/commands/project.py
@@ -3,6 +3,7 @@ import typing as t
 
 import typer
 import yaml
+from rich.control import Control
 
 from config_keeper import config, console, settings
 from config_keeper import exceptions as exc
@@ -154,11 +155,15 @@ def list_(
 
 
 def _check_remote(repository: str):
-    console.print(f'Checking {repository}...', end=' ')
+    msg = f'Checking {repository}...'
+    console.print(msg)
     try:
-        ping_remote(repository, log=True)
+        ping_remote(repository, capture=True)
+        console.control(Control.move(y=-1, x=len(msg)+1))
         console.print('OK', style='green')
     except subprocess.CalledProcessError as exc:
-        print_error(f'\n\n{exc.stderr}')
+        msg = exc.stdout + exc.stderr
+        msg = '\n    ' + msg.replace('\n', '\n    ')
+        print_error(msg)
         if not typer.confirm('Do you want to continue?'):
             raise typer.Exit from exc

--- a/config_keeper/sync_handler.py
+++ b/config_keeper/sync_handler.py
@@ -101,7 +101,7 @@ class SyncHandler:
 
         paths = self.conf['projects'][self.project]['paths']
         for path_name, str_path in paths.items():
-            path = Path(str_path)
+            path = Path(str_path).expanduser().resolve()
             dest = str(directory / path_name)
             copy_args = (str_path, dest)
             if path.is_file():
@@ -115,7 +115,7 @@ class SyncHandler:
 
         for path_name, str_path in paths.items():
             source = directory / path_name
-            dest = Path(str_path)
+            dest = Path(str_path).expanduser().resolve()
             copy_args = (str(source), str_path)
             if source.exists():
                 if dest.is_file():

--- a/config_keeper/validation.py
+++ b/config_keeper/validation.py
@@ -26,10 +26,10 @@ path_regex = re.compile(r'^[\w\/~\-\. ]+$')
 def ping_remote(
     repository: str,
     *,
-    log: bool = False,
+    capture: bool = False,
 ) -> subprocess.CompletedProcess[bytes] | subprocess.CompletedProcess[str]:
     cmd = ['git', 'ls-remote', repository, 'HEAD']
-    if log:
+    if capture:
         return subprocess.run(cmd, check=True, capture_output=True, text=True)
     return subprocess.run(
         cmd,

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -3,7 +3,7 @@ from uuid import uuid1
 
 from config_keeper import config, settings
 
-from tests.helpers import invoke
+from tests.helpers import create_dir, create_file, create_repo, invoke
 
 
 def test_path():
@@ -86,6 +86,73 @@ def test_validate():
         '\nCritical: "projects" is not a map.\n'
     )
 
+
+def test_validate_files_permissions():
+    file_without_read_perm = create_file(
+        name='file_without_read_perm',
+    )
+    file_without_write_perm = create_file(
+        name='file_without_write_perm',
+    )
+    dir_without_write_perm = create_dir(
+        name='dir_without_write_perm',
+    )
+    dir_without_exec_perm = create_dir(
+        name='dir_without_exec_perm',
+    )
+    file_in_dir = create_file(
+        parent=dir_without_exec_perm,
+        name='file_in_dir',
+    )
+
+    file_without_read_perm.chmod(0o333)
+    file_without_write_perm.chmod(0o444)
+    dir_without_exec_perm.chmod(0o666)
+    dir_without_write_perm.chmod(0o555)
+
+    repo = create_repo()
+
+    config.save({
+        'projects': {
+            'test1': {
+                'branch': 'mybranch',
+                'repository': str(repo),
+                'paths': {
+                    'file_without_read_perm': str(file_without_read_perm),
+                    'file_without_write_perm': str(file_without_write_perm),
+                    'file_in_dir': str(file_in_dir),
+                    'dir_without_exec_perm': str(dir_without_exec_perm),
+                    'dir_without_write_perm': str(dir_without_write_perm),
+                },
+            },
+        },
+    })
+
+    result = invoke(['config', 'validate'])
+    assert result.exit_code == 201
+    formatted_stdout = result.stdout.replace('\n', ' ').replace('  ', ' ')
+    assert (
+        'Error: "projects.test1.paths.file_without_read_perm" is not '
+        f'copyable because {file_without_read_perm} has no read '
+        'permission.'
+    ) in formatted_stdout
+    assert (
+        f'Error: "projects.test1.paths.file_in_dir" is not accessible '
+        f'because {file_in_dir.parent} has no execute permission.'
+    ) in formatted_stdout
+    assert (
+        f'Error: "projects.test1.paths.dir_without_exec_perm" is not '
+        f'copyable because {dir_without_exec_perm} has no '
+        'execute permission.'
+    ) in formatted_stdout
+    assert (
+        'Error: "projects.test1.paths.file_without_write_perm" is not '
+        f'writeable because {file_without_write_perm} has no write permission.'
+    ) in formatted_stdout
+    assert (
+        'Error: "projects.test1.paths.dir_without_write_perm" is not writeable '
+        f'because {dir_without_write_perm} has no write permission.'
+    ) in formatted_stdout
 
 def test_config_is_not_a_valid_yaml():
     settings.CONFIG_FILE.write_text('%$%$# not valid yaml\n\n\n\n')

--- a/tests/commands/test_paths.py
+++ b/tests/commands/test_paths.py
@@ -41,11 +41,9 @@ def test_add():
         'paths', 'add', '--project', 'test1', 'invalid_arg::',
     ])
     assert result.exit_code == 205
-    assert result.stdout == (
-        'Error: invalid_arg:: is an invalid argument. Format must be as '
-        'follows:\n\n'
-        'key:/path/to/file/or/folder\n'
-    )
+    assert 'Error: invalid_arg:: is an invalid argument.' in result.stdout
+    assert 'Format must be as follows:' in result.stdout
+    assert 'path_name:/path/to/file/or/folder' in result.stdout
     assert config.load() == current_config
 
     some_file = create_file()

--- a/tests/commands/test_project.py
+++ b/tests/commands/test_project.py
@@ -28,7 +28,7 @@ def test_create():
     assert 'Repository:' in result.stdout
     assert 'Branch [main]:' in result.stdout
     assert 'Checking' in result.stdout
-    assert '... OK' in result.stdout
+    assert 'OK' in result.stdout
     assert 'Project "test1" saved.' in result.stdout
     assert config.load() == {
         'projects': {
@@ -47,7 +47,7 @@ def test_create():
     ], input='y\ny\n')
     assert result.exit_code == 0, result.stdout
     assert 'Checking' in result.stdout
-    assert '... Error: \n\n' in result.stdout
+    assert 'Error:' in result.stdout
     assert 'Do you want to continue? [y/N]:' in result.stdout
     assert 'Project "test1" already exists.' in result.stdout
     assert 'Would you like to overwrite it? [y/N]:' in result.stdout
@@ -69,7 +69,7 @@ def test_create():
     ], input='n\n')
     assert result.exit_code == 0, result.stdout
     assert 'Checking' in result.stdout
-    assert '... OK' in result.stdout
+    assert 'OK' in result.stdout
     assert 'Project "test1" already exists.' in result.stdout
     assert 'Would you like to overwrite it? [y/N]:' in result.stdout
     assert config.load() == {
@@ -130,7 +130,7 @@ def test_update():
     ])
     assert result.exit_code == 0
     assert 'Checking' in result.stdout
-    assert '... OK' in result.stdout
+    assert 'OK' in result.stdout
     assert 'Project "test1" saved.' in result.stdout
 
     # update repository (exit)
@@ -138,7 +138,8 @@ def test_update():
         'project', 'update', 'test1', '--repository', 'invalid',
     ], input='n\n')
     assert result.exit_code == 0
-    assert result.stdout.startswith('Checking invalid... Error: \n\n')
+    assert result.stdout.startswith('Checking invalid...')
+    assert 'Error:' in result.stdout
     assert result.stdout.endswith('Do you want to continue? [y/N]: n\n')
 
 

--- a/tests/commands/test_project.py
+++ b/tests/commands/test_project.py
@@ -159,7 +159,7 @@ def test_delete():
         '  branch: custom\n'
         '  paths: {}\n'
         '  repository: invalid/repo\n\n'
-        'Confirm? [y/N]: n\n'
+        'Proceed? [Y/n]: n\n'
     )
     assert config.load() == test_config
 
@@ -172,7 +172,7 @@ def test_delete():
         '  branch: custom\n'
         '  paths: {}\n'
         '  repository: invalid/repo\n\n'
-        'Confirm? [y/N]: y\n'
+        'Proceed? [Y/n]: y\n'
         'Project "test1" deleted.\n'
     )
     assert config.load() == {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,16 @@ import shutil
 import pytest
 from config_keeper import settings
 
-from tests.helpers import TMP_DIR, id_generator
+from tests.helpers import TMP_DIR, id_generator, run_cmd
 
 get_config_file_id = id_generator()
 
 
 @pytest.fixture(scope='session', autouse=True)
 def _setup_session():
-    shutil.rmtree(TMP_DIR, ignore_errors=True)
+    if TMP_DIR.exists():
+        run_cmd(['chmod', '-R', '777', str(TMP_DIR)])
+        shutil.rmtree(TMP_DIR)
     TMP_DIR.mkdir(parents=True)
 
 


### PR DESCRIPTION
* Feature: validate paths if they're copyable/writable (closes #8).
* Feature: improve output when checking repository (closes #14).
* Feature: asking for project deletion now has default "Y".
* Fix: rename "key" to "path_name" in ``paths add`` error.
* Fix: expand ``~`` and resolve path before syncing.
