### PR TITLE
Change config dir, update doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ repository
 * [Use cases](#use-cases)
 * [Key features](#key-features)
 * [Install](#install)
+  * [Using pipx (recommended)](#using-pipx-recommended)
   * [Using pip](#using-pip)
 * [Usage](#usage)
   * [Quick start](#quick-start)
@@ -48,6 +49,14 @@ using ``validate`` command after
 * User-friendly error messages if something goes wrong
 
 ## Install
+
+### Using pipx (recommended)
+
+[Install ``pipx``](https://pypa.github.io/pipx/installation/) first.
+
+```shell
+pipx install config-keeper2
+```
 
 ### Using pip
 

--- a/config_keeper/__settings.py
+++ b/config_keeper/__settings.py
@@ -1,8 +1,12 @@
 import os
 from pathlib import Path
 
+import typer
+
 # paths
-_DEFAULT_CONFIG_FILE = Path.home() / '.config-keeper.yaml'
+_DEFAULT_CONFIG_FILE = (
+    Path(typer.get_app_dir('config-keeper', roaming=False)) / 'config.yaml'
+)
 CONFIG_FILE = Path(os.getenv('CONFIG_KEEPER_CONFIG_FILE', _DEFAULT_CONFIG_FILE))
 
 # etc

--- a/config_keeper/commands/__init__.py
+++ b/config_keeper/commands/__init__.py
@@ -19,6 +19,7 @@ if t.TYPE_CHECKING:
 cli = typer.Typer(
     name=settings.EXECUTABLE_NAME,
     help='CLI tool for keeping your personal config files in a repository',
+    pretty_exceptions_show_locals=False,
 )
 
 cli.add_typer(project_cli, name='project', help='Manage projects.')

--- a/config_keeper/config.py
+++ b/config_keeper/config.py
@@ -28,8 +28,11 @@ def populate_defaults(config: dict[str, t.Any]):
 
 
 def ensure_exists():
-    settings.CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    settings.CONFIG_FILE.touch()
+    try:
+        settings.CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        settings.CONFIG_FILE.touch()
+    except OSError as e:
+        raise exc.PublicError(str(e)) from e
 
 
 def load() -> TConfig:
@@ -50,6 +53,8 @@ def load() -> TConfig:
             'after.'
         )
         raise exc.InvalidConfigError(msg, tip=tip) from e
+    except OSError as e:
+        raise exc.PublicError(str(e)) from e
 
     config = config or {}
 

--- a/config_keeper/exceptions.py
+++ b/config_keeper/exceptions.py
@@ -8,10 +8,6 @@ class ConfigKeeperError(Exception):
     pass
 
 
-class InternalError(ConfigKeeperError):
-    pass
-
-
 class PublicError(typer.Exit, ConfigKeeperError):
     exit_code = 255  # default
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "config-keeper2"
-version = "1.0.0a4"
+version = "1.0.0"
 description = "CLI tool for keeping your personal config files in a repository"
 authors = ["Vladislav Korenkov <vladnfs3@gmail.com>"]
 readme = "README.md"

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -224,3 +224,20 @@ def test_empty_config_is_valid():
     result = invoke(['config', 'validate'])
     assert result.exit_code == 0
     assert config.load() == {'projects': {}}
+
+
+def test_oserror_for_config_file():
+    somefile = create_file()
+    somefile.chmod(0o333)
+    settings.CONFIG_FILE = somefile
+
+    result = invoke(['config', 'validate'])
+    assert result.exit_code == 255
+    assert 'Permission denied' in result.stdout
+
+    somedir = create_dir()
+    somedir.chmod(0o000)
+    settings.CONFIG_FILE = somedir / 'somefile'
+    result = invoke(['config', 'validate'])
+    assert result.exit_code == 255
+    assert 'Permission denied' in result.stdout


### PR DESCRIPTION
BREAKING CHANGES:
* Config file location according to standard app home directory depend on OS (e.g. for linux it's located now at ``$HOME/.config/config-keeper/config.yaml``) (closes #30).

Changelog:
* Fix: handle possible permission error when changing config file location via env variable.
* Docs: describe installation via ``pipx`` as recommended method (closes #29) 